### PR TITLE
simplify esc-exit a bit

### DIFF
--- a/etc/userdef.d/40-escape
+++ b/etc/userdef.d/40-escape
@@ -1,10 +1,9 @@
 # vim:ft=zsh
 
 # Make zsh exit on escape
-# TODO: there has to be an easier way then this…
-function __shellex_exit {
+function _shellex_exit {
     exit
 }
-zle -N _shellex_exit __shellex_exit
+zle -N _shellex_exit
 bindkey '^[' _shellex_exit
 


### PR DESCRIPTION
As far as I can tell, this is the intended way for something like this. bindkey only accepts widget functions and widget functions are defined by calling `zle -N` on a shell function. It is not possible to directly call builtins. 

A shorter version would be `bindkey -s '^[' '^qexit\n'`, but that effectively types for the user. I.e., on hitting esc, it writes `^qexit\n`. This works fine until the users decides to rebind `^q`, so it shouldn’t be used as default.

These are the only two methods that have been suggested on [the zsh mailinglist](http://www.zsh.org/mla/users/2011/msg00171.html), so I doubt it gets any simpler than this.
