### PR TITLE
enable history usage

### DIFF
--- a/conf/10-autoexec
+++ b/conf/10-autoexec
@@ -12,6 +12,9 @@ function accept-line () {
     # commands (see https://github.com/Merovius/shellex/issues/11). We let the
     # shell immediately remove the tempfile, so it's rather short-lived.
     file=`mktemp -t shellex_exec-XXXXXXXX`
+
+    # manually write history to histfile
+    # this is indeed more hack, the child zsh which executes $file should do this
     if [ -n "$HISTFILE" ]
     then
        echo $BUFFER >> $HISTFILE
@@ -20,6 +23,8 @@ function accept-line () {
 
     # Execute the tempfile, then exit
     BUFFER="zsh $file > /dev/null 2>&1 & disown; exit"
+
+    # prevent writing meaningless "zsh $file > /dev/null ...." to history
     unset HISTFILE
     zle .accept-line
 }

--- a/conf/90-hist
+++ b/conf/90-hist
@@ -1,3 +1,5 @@
+# histfile enabling and forcing to read the history after setting it
+# © 2013 Paul Seyfert and contributors (see also: LICENSE)
 setopt sharehistory
 setopt appendhistory
 HISTSIZE=100


### PR DESCRIPTION
as stated here https://github.com/Merovius/shellex/issues/14#issuecomment-23702019 it's not fully working. currently I need to push an arrow key to let shellex behave properly, but commands get written to the historyfile (as inspried by https://github.com/Merovius/shellex/issues/14#issuecomment-22812163 ) and get read (fc -R in conf/90-hist)
