### PR TITLE
added sudo-Support with gksudo (optional config)

### DIFF
--- a/conf/40-sudo
+++ b/conf/40-sudo
@@ -1,0 +1,4 @@
+# vim:ft=zsh
+# use gksudo instead of sudo
+# © 2013 Johannes Visintini and contributors (see also: LICENSE)
+alias sudo='gksudo'


### PR DESCRIPTION
i wish to use sudo (not gksudo) in shellex. The easiest way I found was to use an zsh-alias on gksudo. Maybe someone want to use it too. So I added it to the confs, but only as optional — not as default.

If you want to merge it (and release it) don't forget to add gksudo as optional dependence.
