### PR TITLE
rearranged .mk files

### DIFF
--- a/preload/preload.mk
+++ b/preload/preload.mk
@@ -2,8 +2,8 @@ ALL_TARGETS += preload/shellex_preload.so
 INSTALL_TARGETS += install-shellex_preload
 CLEAN_TARGETS += clean-shellex_preload
 
-SHELLEX_CFLAGS=-fPIC
-SHELLEX_PRELOAD_LDFLAGS=-shared
+SHELLEX_PRELOAD_LDFLAGS += -shared
+SHELLEX_PRELOAD_CFLAGS += -fPIC
 
 preload/shellex_preload.so: preload/main.c
 	echo "[CC] $@"

--- a/shellex.mk
+++ b/shellex.mk
@@ -2,9 +2,6 @@ ALL_TARGETS += shellex
 INSTALL_TARGETS += install-shellex
 CLEAN_TARGETS += clean-shellex
 
-SHELLEX_CFLAGS=-fPIC
-SHELLEX_PRELOAD_LDFLAGS=-shared
-
 shellex: shellex.in
 	echo "[SED] $@"
 	$(SED) $(sed_replace_vars) $< > $@


### PR DESCRIPTION
Flags for the preload library moved from shellex.mk to preload/preload.mk, and prevent flags from overwriting each other