### PR TITLE
[work in progress] Avoid creating a temporary conffile

### DIFF
--- a/conf.mk
+++ b/conf.mk
@@ -1,6 +1,6 @@
 INSTALL_TARGETS += install-conf
 
-default_confs := 10-autoexec 40-escape 40-home_end 40-setprompt 40-sigint 90-hist 99-clear
+default_confs := 10-def_autoexec 40-escape 40-home_end 40-setprompt 40-sigint 90-hist 99-apply_autoexec
 
 install-conf:
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(PREFIX)$(LIBDIR)/shellex/conf

--- a/conf/10-def_autoexec
+++ b/conf/10-def_autoexec
@@ -39,6 +39,5 @@ function shellex_preexec () {
     exit
 }
 
-# We use preexec_functions, so that the user can decide to overwrite our choice
-# or ammend it by own functions
-preexec_functions=(shellex_preexec)
+# The preexec function will be set later not to affect the remaining conf files,
+# but defined now, so that the user can overwrite it.

--- a/conf/99-apply_autoexec
+++ b/conf/99-apply_autoexec
@@ -1,0 +1,5 @@
+# vim:ft=zsh
+# We use preexec_functions, so that the user can decide to overwrite our choice
+# or ammend it by own functions.
+# Clear the terminal-window at last, but before the preexec_functions is active.
+preexec_functions=(shellex_preexec) ; clear

--- a/conf/99-apply_autoexec
+++ b/conf/99-apply_autoexec
@@ -2,4 +2,12 @@
 # We use preexec_functions, so that the user can decide to overwrite our choice
 # or ammend it by own functions.
 # Clear the terminal-window at last, but before the preexec_functions is active.
-preexec_functions=(shellex_preexec) ; clear
+
+# preexec_functions is only set if the user didn't provide their own.  If so,
+# we leave it to the user add shellex_preexec to preexec_functions, if they
+# want to.
+if [[ -z $preexec_functions ]]
+then
+  preexec_functions=(shellex_preexec)
+fi
+clear

--- a/conf/99-clear
+++ b/conf/99-clear
@@ -1,4 +1,0 @@
-# vim:ft=zsh
-# Clear the terminal-window at start
-# © 2013 Axel Wagner and contributors (see also: LICENSE)
-clear

--- a/urxvt/shellex.in
+++ b/urxvt/shellex.in
@@ -128,35 +128,6 @@ sub geometry_from_focus {
     }
 }
 
-sub slurp {
-    open my $fh, '<', shift;
-    local $/;
-    <$fh>;
-}
-
-sub gen_conf {
-    my ($cfg, $cfgname) = tempfile("/tmp/shellex-XXXXXXXX", UNLINK => 0);
-
-    print $cfg "rm $cfgname\n";
-
-    my %fileset;
-    map { $fileset{basename($_)} = 1 } <@SYSCONFDIR@/shellex/*>;
-    map { $fileset{basename($_)} = 1 } <$ENV{HOME}/.shellex/*>;
-
-    my @files = sort keys %fileset;
-
-    for my $f (@files) {
-        if (-e "$ENV{HOME}/.shellex/$f") {
-            print $cfg slurp("$ENV{HOME}/.shellex/$f");
-        } else {
-            print $cfg slurp("@SYSCONFDIR@/shellex/$f");
-        }
-    }
-    close($cfg);
-
-    return $cfgname;
-}
-
 # This hook is run when the extension is first initialized, before any windows
 # are created or mapped. There is not much work we can do here.
 sub on_init {
@@ -221,9 +192,22 @@ sub on_start {
 
     $self->XMoveResizeWindow($self->parent, $self->{x}, $y, $self->{w}, $height);
 
-    my $cfg = gen_conf();
+    print "loading config\n";
+    $self->tt_write($self->locale_encode("unset LD_PRELOAD\n"));
 
-    $self->tt_write($self->locale_encode(". $cfg\n"));
+    my %fileset;
+    map { $fileset{basename($_)} = 1 } <@SYSCONFDIR@/shellex/*>;
+    map { $fileset{basename($_)} = 1 } <$ENV{HOME}/.shellex/*>;
+
+    my @files = sort keys %fileset;
+
+    for my $f (@files) {
+        if (-e "$ENV{HOME}/.shellex/$f") {
+            $self->tt_write($self->locale_encode(". $ENV{HOME}/.shellex/$f\n"));
+        } else {
+            $self->tt_write($self->locale_encode(". @SYSCONFDIR@/shellex/$f\n"));
+        }
+    }
     ();
 }
 


### PR DESCRIPTION
Avoid concatenating the conf files into a temporary file.

Instead all conf files are sourced.

To avoid the preexec function being applied immediately to sourcing the other conf files, it is activated in the last file. To preserve the behaviour that the user can override the preexec function, it is tested if preexec_functions is set (this doesn't work at the moment, because the user's preexec will become active too soon).

Would it make more sense looping over all conf files in a shell-script (instead of the urxvt perl module)? Such that perl only writes one `source`. The change wrt what is done in the master at the moment is not to source a temporary concatenation.
