### PR TITLE
add missing default-conf to conf.mk

### DIFF
--- a/conf.mk
+++ b/conf.mk
@@ -1,6 +1,6 @@
 INSTALL_TARGETS += install-conf
 
-default_confs := 10-autoexec 40-escape 40-home_end 40-setprompt 40-sigint 90-hist 99-clear
+default_confs := 10-autoexec 40-escape 40-home_end 40-setprompt 40-sigint 40-sudo 90-hist 99-clear
 
 install-conf:
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(PREFIX)$(LIBDIR)/shellex/conf


### PR DESCRIPTION
`40-sudo` was added in d7947a19c3a32b9d19cf4e71f5e22c27ddad2e4a to the conf directory but not to `conf.mk`.
