### PR TITLE
respect $DESTDIR when linking conf files

### DIFF
--- a/conf.mk
+++ b/conf.mk
@@ -8,8 +8,9 @@ install-conf:
 	do \
 		$(INSTALL) -m 0644 $${file} $(DESTDIR)$(PREFIX)$(LIBDIR)/shellex/conf/; \
 	done
+	# NB: no PREFIX needed between DESTDIR and SYSCONFDIR
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(SYSCONFDIR)/shellex
 	for link in $(default_confs); \
 	do \
-		[ -e $(DESTDIR)$(SYSCONFDIR)/shellex/$${link} ] || ln -s $(PREFIX)$(LIBDIR)/shellex/conf/$${link} $(DESTDIR)$(SYSCONFDIR)/shellex; \
+		[ -e $(DESTDIR)$(SYSCONFDIR)/shellex/$${link} ] || ln -s $(DESTDIR)$(PREFIX)$(LIBDIR)/shellex/conf/$${link} $(DESTDIR)$(SYSCONFDIR)/shellex; \
 	done

--- a/doc/man/shellex.man.in
+++ b/doc/man/shellex.man.in
@@ -49,10 +49,10 @@ terminal window.
 
 == CONFIGURATION
 
-*shellex* configuration snippets can be found in *@PREFIX@@LIBDIR@/shellex/*.
+*shellex* configuration snippets can be found in *@DESTDIR@@PREFIX@@LIBDIR@/shellex/*.
 
-On start, *shellex* looks into @SYSCONFDIR@/shellex for default-snippets to
-source (usually this will be symlinks to *@PREFIX@@LIBDIR@/shellex/*) as well
+On start, *shellex* looks into @DESTDIR@@SYSCONFDIR@/shellex for default-snippets to
+source (usually this will be symlinks to *@DESTDIR@@PREFIX@@LIBDIR@/shellex/*) as well
 as into *$HOME/.shellex/* for any user-configuration. If a file of the same
 name exists in both locations, it will only use the one in *$HOME/.shellex/*.
 
@@ -60,7 +60,7 @@ To customize shellex, you can do the following things in *$HOME/.shellex/*:
 
 1. Overwrite a default by creating a new snippet of the same name
 2. Not include a default by creating a symlink to */dev/null* of the same same
-3. Include an example-snippet not used by default, by creating a symlink to *@PREFIX@@LIBDIR@/shellex/snippet*
+3. Include an example-snippet not used by default, by creating a symlink to *@DESTDIR@@PREFIX@@LIBDIR@/shellex/snippet*
 4. Write you own snippets with a currently unused name
 
 To avoid naming-conflicts in the future, you should add a common suffix to all

--- a/shellex.in
+++ b/shellex.in
@@ -5,5 +5,5 @@
 # © 2013 Axel Wagner and contributors (see also: LICENSE)
 
 
-export LD_PRELOAD="@PREFIX@@LIBDIR@/shellex/shellex_preload.so"
-exec urxvt -perl-lib @PREFIX@@LIBDIR@/shellex/urxvt -pe shellex -override-redirect -name shellex $* -e env -u LD_PRELOAD zsh -f
+export LD_PRELOAD="@DESTDIR@@PREFIX@@LIBDIR@/shellex/shellex_preload.so"
+exec urxvt -perl-lib @DESTDIR@@PREFIX@@LIBDIR@/shellex/urxvt -pe shellex -override-redirect -name shellex $* -e env -u LD_PRELOAD zsh -f

--- a/urxvt/shellex.in
+++ b/urxvt/shellex.in
@@ -140,7 +140,7 @@ sub gen_conf {
     print $cfg "rm $cfgname\n";
 
     my %fileset;
-    map { $fileset{basename($_)} = 1 } <@SYSCONFDIR@/shellex/*>;
+    map { $fileset{basename($_)} = 1 } <@DESTDIR@@SYSCONFDIR@/shellex/*>;
     map { $fileset{basename($_)} = 1 } <$ENV{HOME}/.shellex/*>;
 
     my @files = sort keys %fileset;
@@ -149,7 +149,7 @@ sub gen_conf {
         if (-e "$ENV{HOME}/.shellex/$f") {
             print $cfg slurp("$ENV{HOME}/.shellex/$f");
         } else {
-            print $cfg slurp("@SYSCONFDIR@/shellex/$f");
+            print $cfg slurp("@DESTDIR@@SYSCONFDIR@/shellex/$f");
         }
     }
     close($cfg);


### PR DESCRIPTION
The install location of the conf files was inconsistent between installing them (`$DESTDIR$PREFIX$LIBDIR`) and linking them (`$PREFIX$LIBDIR`). Also added a comment before for future readers not to suspect that `$PREFIX` was forgotten in the `$SYSCONFDIR` locations. (`$DESTDIR$PREFIX$LIBDIR` contains `$DESTDIR` and `$PREFIX`, but `$DESTDIR$SYSCONFDIR` goes without `$PREFIX`).