### PR TITLE
change urxvt CSI sequence

### DIFF
--- a/urxvt/shellex.in
+++ b/urxvt/shellex.in
@@ -249,7 +249,7 @@ sub on_line_update {
     if ($self->{bottom}) {
         $y -= 2 + $nrow * $self->fheight;
     }
-    $self->cmd_parse("\e[8;$nrow;t\e[3;$self->{x};${y}t");
+    $self->cmd_parse("\e[24;$nrow;t\e[3;$self->{x};${y}t");
     ();
 }
 
@@ -327,7 +327,7 @@ sub on_add_lines {
     if ($self->{bottom}) {
         $y -= 2 + $nrow * $self->fheight;
     }
-    $self->cmd_parse("\e[8;$nrow;t\e[3;$self->{x};${y}t");
+    $self->cmd_parse("\e[24;$nrow;t\e[3;$self->{x};${y}t");
     ();
 }
 


### PR DESCRIPTION
switch from ESC [ 8 ; ... t to ESC [ 24 ; ... t

 * 24 does not require a column specification
 * 8 is handled differently in xterm and urxvt: in xterm omitted parameters are "leave as is" and zero values are "as big as the desktop". in urxvt omitted values are defaulted to 0 and thus handled the same as 0, which is "as big as the desktop".

Here we only want to resize vertically and not span over several screens.